### PR TITLE
Fix integration guide URL

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,7 +2,7 @@
   <header>
     <h1>DatoCMS + Nuxt Starter Kit</h1>
     <nav>
-      <a class="navlink" href="https://www.datocms.com/docs/next-js"> 📚 Full Integration Guide </a>
+      <a class="navlink" href="https://www.datocms.com/docs/nuxt"> 📚 Full Integration Guide </a>
       <DraftModeToggler />
     </nav>
   </header>


### PR DESCRIPTION
The Nuxt demo shouldn't point to the Next docs :)

This fixes the link to go to https://www.datocms.com/docs/nuxt instead. (Alternatively, we could link to https://www.datocms.com/blog/how-to-build-a-nuxt-blog instead, but that's also mentioned on the docs page).