### PR TITLE
Fix open redirect in nuxt-starter-kit draft-mode handlers

### DIFF
--- a/lib/api/utils.ts
+++ b/lib/api/utils.ts
@@ -52,19 +52,25 @@ export function handleUnexpectedError(error: unknown) {
   });
 }
 
-export function isRelativeUrl(path: string): boolean {
+/**
+ * Determine whether a user-supplied redirect target is safe to follow — i.e. it
+ * points to the same host as the current request.
+ *
+ * This guards against open-redirect attacks. A naive `url.startsWith('http')`
+ * check — and even a plain "is it a relative URL?" check — fails to catch
+ * protocol-relative targets like `//evil.com` or backslash variants like
+ * `/\evil.com`, both of which browsers happily send off-site.
+ *
+ * Instead, we resolve the candidate against the current request URL and require
+ * the resulting hostname to match. Relative paths (`/foo`, `/a?b=1#c`) resolve
+ * to the same host and pass; anything that escapes to another host — or fails to
+ * parse — is rejected.
+ */
+export function isSafeRedirectUrl(candidate: string, requestUrl: URL): boolean {
   try {
-    // Try to create a URL object — if it succeeds without a base, it's absolute
-    new URL(path);
-    return false;
+    const target = new URL(candidate, requestUrl);
+    return target.hostname === requestUrl.hostname;
   } catch {
-    try {
-      // Verify it can be parsed as a relative URL by providing a base
-      new URL(path, 'http://example.com');
-      return true;
-    } catch {
-      // If both attempts fail, it's not a valid URL at all
-      return false;
-    }
+    return false;
   }
 }

--- a/server/api/draft-mode/disable.ts
+++ b/server/api/draft-mode/disable.ts
@@ -1,5 +1,5 @@
 import { disableDraftMode } from '~/lib/api/draftMode';
-import { ensureHttpMethods, isRelativeUrl } from '~/lib/api/utils';
+import { ensureHttpMethods, isSafeRedirectUrl } from '~/lib/api/utils';
 
 /*
  * This API route disables Draft Mode, by deleting the signed cookie.
@@ -12,7 +12,7 @@ export default eventHandler(async (event) => {
   const url = query.redirect || '/';
 
   // Avoid open redirect vulnerabilities
-  if (!isRelativeUrl(url)) {
+  if (!isSafeRedirectUrl(url, getRequestURL(event))) {
     throw createError({ status: 422, message: 'URL must be relative!' });
   }
 

--- a/server/api/draft-mode/enable.ts
+++ b/server/api/draft-mode/enable.ts
@@ -1,5 +1,5 @@
 import { enableDraftMode } from '~/lib/api/draftMode';
-import { ensureHttpMethods, isRelativeUrl } from '~/lib/api/utils';
+import { ensureHttpMethods, isSafeRedirectUrl } from '~/lib/api/utils';
 
 /*
  * This API route enables Draft Mode. If the token is correct, it writes the API
@@ -23,7 +23,7 @@ export default eventHandler(async (event) => {
   }
 
   // Avoid open redirect vulnerabilities
-  if (!isRelativeUrl(url)) {
+  if (!isSafeRedirectUrl(url, getRequestURL(event))) {
     throw createError({ status: 422, message: 'URL must be relative!' });
   }
 


### PR DESCRIPTION
The previous isRelativeUrl() check accepted protocol-relative targets like //evil.com and backslash variants like /\evil.com, which browsers follow off-site — leaving an open redirect on both draft-mode endpoints (disable has no token gate at all).

Replace it with isSafeRedirectUrl(), which resolves the candidate against the current request URL and requires the hostname to match.